### PR TITLE
#52 - 프로덕션 환경에서 소셜 로그인 되지 않는 버그 수정

### DIFF
--- a/src/components/social/OAuth2RedirectHandler.js
+++ b/src/components/social/OAuth2RedirectHandler.js
@@ -6,7 +6,7 @@ import Spinner from "../common/Spinner";
 const OAuth2RedirectHandler = () => {
 
   const [loading, setLoading] = useState(false);
-  const baseRedirectUri = "http://localhost:3000/oauth2/callback/";
+  const baseRedirectUri = process.env.REACT_APP_BASE_REDIRECT_URI;
 
   const string = window.location.href.split("?")[0];
   // * 으로 매핑된 Provider 정보 가져오기


### PR DESCRIPTION
원인 : `OAuth2RedirectHandler`에서 소셜 로그인 제공자가 리다이렉트 시킨 URI를 받아와 처리합니다. 운영 환경에서 바뀐 URI를 적용하지 않아서 발생한 문제입니다.

해결 방법 : 운영 환경에서 바뀐 URI를 적용시켜  주었습니다.